### PR TITLE
Support 4 server environments

### DIFF
--- a/Shared/Config.m
+++ b/Shared/Config.m
@@ -29,4 +29,8 @@
     return MACRO_STRING(BASE_DOMAIN3);
 }
 
++ (NSString *) baseDomain4 {
+    return MACRO_STRING(BASE_DOMAIN4);
+}
+
 @end

--- a/wwWallet-Info.plist
+++ b/wwWallet-Info.plist
@@ -25,6 +25,7 @@
 		<string>$(BASE_DOMAIN1)</string>
 		<string>$(BASE_DOMAIN2)</string>
 		<string>$(BASE_DOMAIN3)</string>
+		<string>$(BASE_DOMAIN4)</string>
 	</array>
 	<key>com.apple.developer.nfc.readersession.iso7816.select-identifiers</key>
 	<array>

--- a/wwWallet.xcodeproj/project.pbxproj
+++ b/wwWallet.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 				"  -e \"s/{{BASE_DOMAIN1}}/$BASE_DOMAIN1/g\" \\",
 				"  -e \"s/{{BASE_DOMAIN2}}/$BASE_DOMAIN2/g\" \\",
 				"  -e \"s/{{BASE_DOMAIN3}}/$BASE_DOMAIN3/g\" \\",
+				"  -e \"s/{{BASE_DOMAIN4}}/$BASE_DOMAIN4/g\" \\",
 				"  \"$TEMPLATE\" > \"$DEST\"",
 				"",
 			);

--- a/wwWallet/Settings.bundle/Root.plist.template
+++ b/wwWallet/Settings.bundle/Root.plist.template
@@ -20,12 +20,14 @@
 				<string>{{BASE_DOMAIN1}}</string>
 				<string>{{BASE_DOMAIN2}}</string>
 				<string>{{BASE_DOMAIN3}}</string>
+				<string>{{BASE_DOMAIN4}}</string>
 			</array>
 			<key>Values</key>
 			<array>
 				<string>0</string>
 				<string>1</string>
 				<string>2</string>
+				<string>3</string>
 			</array>
 		</dict>
 	</array>

--- a/wwWallet/wwWallet.entitlements
+++ b/wwWallet/wwWallet.entitlements
@@ -7,9 +7,11 @@
 		<string>webcredentials:$(BASE_DOMAIN1)</string>
 		<string>webcredentials:$(BASE_DOMAIN2)</string>
 		<string>webcredentials:$(BASE_DOMAIN3)</string>
+		<string>webcredentials:$(BASE_DOMAIN4)</string>
 		<string>applinks:$(BASE_DOMAIN1)</string>
 		<string>applinks:$(BASE_DOMAIN2)</string>
 		<string>applinks:$(BASE_DOMAIN3)</string>
+		<string>applinks:$(BASE_DOMAIN4)</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>


### PR DESCRIPTION
SIROS is running a separate wwWallet instance to test the zero-knowledge proof fork and we'd like to test it with the iOS app on TestFlight. I've added `BASE_DOMAIN4` to support an additional environment in the settings. Hope I got it right!

The server environment for `BASE_DOMAIN4` is `zkp.diad.nu` 